### PR TITLE
docker-compose NGINX update

### DIFF
--- a/docker-compose/docker-compose-nginx.yml
+++ b/docker-compose/docker-compose-nginx.yml
@@ -1,20 +1,52 @@
 version: '2.3'
+
 services:
-  squidex_mongo:
-    image: mongo:6
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy
+    container_name: nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
     volumes:
-      - /etc/squidex/mongo/db:/data/db
+      - /etc/squidex/nginx/conf.d:/etc/nginx/conf.d
+      - /etc/squidex/nginx/vhost.d:/etc/nginx/vhost.d
+      - /etc/squidex/nginx/html:/usr/share/nginx/html
+      - /etc/squidex/nginx/certs:/etc/nginx/certs:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
     networks:
       - internal
-    restart: unless-stopped
 
-  squidex_squidex:
+  acme-companion:
+    image: nginxproxy/acme-companion
+    container_name: nginx-proxy-acme
+      environment:
+      - DEFAULT_EMAIL=${SQUIDEX_ADMINEMAIL}
+    volumes_from:
+      - nginx-proxy
+    volumes:
+      - /etc/squidex/nginx/certs:/etc/nginx/certs:rw
+      - /etc/acme:/etc/acme.sh
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - internal
+
+  squidex-mongo:
+    image: mongo:6
+    container_name: squidex-mongo
+    volumes:
+      - /etc/squidex/mongo/db:/data/db
+    restart: unless-stopped
+    networks:
+      - internal
+
+  squidex:
     image: "squidex/squidex:7"
+    container_name: squidex
     environment:
       - URLS__BASEURL=https://${SQUIDEX_DOMAIN}
       - EVENTSTORE__TYPE=MongoDB
-      - EVENTSTORE__MONGODB__CONFIGURATION=mongodb://squidex_mongo
-      - STORE__MONGODB__CONFIGURATION=mongodb://squidex_mongo
+      - EVENTSTORE__MONGODB__CONFIGURATION=mongodb://squidex-mongo
+      - STORE__MONGODB__CONFIGURATION=mongodb://squidex-mongo
       - IDENTITY__ADMINEMAIL=${SQUIDEX_ADMINEMAIL}
       - IDENTITY__ADMINPASSWORD=${SQUIDEX_ADMINPASSWORD}
       - IDENTITY__GOOGLECLIENT=${SQUIDEX_GOOGLECLIENT}
@@ -26,49 +58,17 @@ services:
       - LETSENCRYPT_HOST=${SQUIDEX_DOMAIN}
       - LETSENCRYPT_EMAIL=${SQUIDEX_ADMINEMAIL}
       - VIRTUAL_HOST=${SQUIDEX_DOMAIN}
-        #- ASPNETCORE_URLS=http://+:5000
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
+      test: ["CMD", "curl", "-f", "http://localhost:80/healthz"]
       start_period: 60s
     depends_on:
-      - squidex_mongo
+      - squidex-mongo
     volumes:
       - /etc/squidex/assets:/app/Assets
+    restart: unless-stopped
     networks:
       - internal
-    restart: unless-stopped
 
-  squidex_proxy:
-    image: squidex/nginx-proxy
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - /etc/squidex/nginx/vhost.d:/etc/nginx/vhost.d
-      - /etc/squidex/nginx/certs:/etc/nginx/certs:ro
-      - /etc/squidex/nginx/html:/usr/share/nginx/html
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-    depends_on:
-      - squidex_squidex
-    networks:
-      - internal
-    labels:
-      - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
-    restart: unless-stopped
-
-  squidex_encrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
-    volumes:
-      - /etc/squidex/nginx/certs:/etc/nginx/certs:rw
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    volumes_from:
-      - squidex_proxy
-    depends_on:
-      - squidex_proxy
-    networks:
-      - internal
-    restart: unless-stopped
-    
 networks:
   internal:
     driver: bridge

--- a/docker-compose/docker-compose-nginx.yml
+++ b/docker-compose/docker-compose-nginx.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.5'
 
 services:
   nginx-proxy:

--- a/docker-compose/docker-compose-noproxy.yml
+++ b/docker-compose/docker-compose-noproxy.yml
@@ -1,7 +1,7 @@
-version: '2.3'
+version: '3.5'
 services:
   squidex_mongo:
-          image: "mongo:6"
+    image: "mongo:6"
     volumes:
       - /etc/squidex/mongo/db:/data/db
     networks:


### PR DESCRIPTION
This docker-compose nginx no longer works due to various changes.
The new YAML uses acme-companion and nginx-proxy containers.