### PR TITLE
fix: acme-companion indentation error

### DIFF
--- a/docker-compose/docker-compose-nginx.yml
+++ b/docker-compose/docker-compose-nginx.yml
@@ -19,7 +19,7 @@ services:
   acme-companion:
     image: nginxproxy/acme-companion
     container_name: nginx-proxy-acme
-      environment:
+    environment:
       - DEFAULT_EMAIL=${SQUIDEX_ADMINEMAIL}
     volumes_from:
       - nginx-proxy


### PR DESCRIPTION
I ran into this error several times while setting up an EC2 deployment:

```
yaml: line 22: mapping values are not allowed in this context
```

The nginx yaml is not parsed correctly.